### PR TITLE
Set PHP 7.1+ as minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": "MIT",
     "type": "library",
     "require": {
+        "php": "^7.1",
         "guzzlehttp/guzzle": "^6.5",
         "jms/serializer": "^3.6",
         "ext-json": "*"


### PR DESCRIPTION
Project wouldn't work on PHP lower than PHP 7.1 because of methods `void` return types.