### PR TITLE
Add return type to collections accessors

### DIFF
--- a/src/ClientScopes/ClientScopeCollection.php
+++ b/src/ClientScopes/ClientScopeCollection.php
@@ -16,6 +16,9 @@ class ClientScopeCollection extends Collection
      */
     protected $data;
 
+    /**
+     * @return ClientScope[]
+     */
     public function getData()
     {
         return $this->data;

--- a/src/Clients/ClientCollection.php
+++ b/src/Clients/ClientCollection.php
@@ -16,6 +16,9 @@ class ClientCollection extends Collection
      */
     protected $data;
 
+    /**
+     * @return Client[]
+     */
     public function getData()
     {
         return $this->data;

--- a/src/ProtocolMappers/ProtocolMapperCollection.php
+++ b/src/ProtocolMappers/ProtocolMapperCollection.php
@@ -16,6 +16,9 @@ class ProtocolMapperCollection extends Collection
      */
     protected $data;
 
+    /**
+     * @return ProtocolMapper[]
+     */
     public function getData()
     {
         return $this->data;

--- a/src/Realms/RealmCollection.php
+++ b/src/Realms/RealmCollection.php
@@ -16,6 +16,9 @@ class RealmCollection extends Collection
      */
     protected $data;
 
+    /**
+     * @return Realm[]
+     */
     public function getRealms()
     {
         return $this->data;

--- a/src/Roles/RoleCollection.php
+++ b/src/Roles/RoleCollection.php
@@ -20,6 +20,9 @@ class RoleCollection extends Collection implements \JsonSerializable
      */
     protected $data;
 
+    /**
+     * @return Role[]
+     */
     public function getRoles()
     {
         return $this->data;

--- a/src/Users/UserCollection.php
+++ b/src/Users/UserCollection.php
@@ -16,6 +16,9 @@ class UserCollection extends Collection
      */
     protected $data;
 
+    /**
+     * @return User[]
+     */
     public function getUsers()
     {
         return $this->data;


### PR DESCRIPTION
This is useful to help IDE to know what type of data you have in array. Otherwise intellisense wouldn't work.

Instead of:
```php
/** @var \KeycloakAdmin\Realms\Realm[] */
$realms = $keycloakAdmin->realm()->list()->getRealms();
foreach ($realms as $realm) {
    $realmName = $realm->getRealm();
}}
```

We will have only:
```php
$realms = $keycloakAdmin->realm()->list()->getRealms();
foreach ($realms as $realm) {
    $realmName = $realm->getRealm();
}}
```